### PR TITLE
Use netcat-gnu instead of netcat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -114,7 +114,7 @@ with rec
           pkgs.fswatch
           pkgs.gcc
           pkgs.jq
-          pkgs.netcat
+          pkgs.netcat-gnu
         ];
       newBuildInputs =
           if builtins.hasAttr "buildInputs" attrs


### PR DESCRIPTION
@nmattia this change fixes the issue we discussed with being stuck in a loop at `waiting for registry to be alive on port 8080` on Darwin.

I tried it on my NixOS VM and it works as expected there too.