### PR TITLE
Use stdenv.cc instead of pkgs.gcc

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -112,7 +112,6 @@ with rec
         [ pkgs.nodejs
           haskellPackages.napalm-registry
           pkgs.fswatch
-          pkgs.stdenv.cc
           pkgs.jq
           pkgs.netcat-gnu
         ];

--- a/default.nix
+++ b/default.nix
@@ -112,7 +112,7 @@ with rec
         [ pkgs.nodejs
           haskellPackages.napalm-registry
           pkgs.fswatch
-          pkgs.gcc
+          pkgs.stdenv.cc
           pkgs.jq
           pkgs.netcat-gnu
         ];


### PR DESCRIPTION
Is there a specific reason that gcc is needed for certain packages?