### PR TITLE
Use unused port for registry

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -190,16 +190,17 @@ let
             sourceRoot=$PWD
 
             echo "Starting napalm registry"
+            REGISTRY_PORT=$(unusedPort)
 
-            napalm-registry --snapshot ${snapshot} &
+            napalm-registry --port $REGISTRY_PORT --snapshot ${snapshot} &
             napalm_REGISTRY_PID=$!
 
-            while ! nc -z localhost 8081; do
-              echo waiting for registry to be alive on port 8081
+            while ! nc -z localhost $REGISTRY_PORT; do
+              echo waiting for registry to be alive on port $REGISTRY_PORT
               sleep 1
             done
 
-            npm config set registry 'http://localhost:8081'
+            npm config set registry 'http://localhost:$REGISTRY_PORT'
 
             export CPATH="${pkgs.nodejs}/include/node:$CPATH"
 

--- a/default.nix
+++ b/default.nix
@@ -93,14 +93,14 @@ let
   # returns unused ports in a given range
   unusedPort = pkgs.writeScriptBin "unusedPort" ''
     #!${pkgs.stdenv.shell}
-    PATH="$PATH:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.nettools}/bin:${pkgs.gnugrep}/bin"
+    PATH="$PATH:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.lsof}/bin:${pkgs.gnugrep}/bin"
     RANGE_START=''${1:-8000}
     RANGE_END=''${2:-9000}
     N=''${3:-1}
     comm -23 \
        <(seq $RANGE_START $RANGE_END) \
-       <(netstat -aln | grep LISTEN \
-           | sed -n -e 's/.*\.\([[:digit:]]*\) .* /\1/p' \
+       <(lsof -i -P -n \
+           | sed -ne 's/.*:\([[:digit:]]*\) (LISTEN)/\1/p' \
            | sort) \
        | head -n $N
   '';

--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@ let
   # returns unused ports in a given range
   unusedPort = pkgs.writeScriptBin "unusedPort" ''
     #!${pkgs.stdenv.shell}
-    PATH="$PATH:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.lsof}/bin:${pkgs.gnugrep}/bin"
+    PATH="$PATH:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.lsof}/bin"
     RANGE_START=''${1:-8000}
     RANGE_END=''${2:-9000}
     N=''${3:-1}

--- a/default.nix
+++ b/default.nix
@@ -201,7 +201,7 @@ let
               sleep 1
             done
 
-            npm config set registry 'http://localhost:$REGISTRY_PORT'
+            npm config set registry "http://localhost:$REGISTRY_PORT"
 
             export CPATH="${pkgs.nodejs}/include/node:$CPATH"
 

--- a/default.nix
+++ b/default.nix
@@ -194,6 +194,7 @@ let
 
             napalm-registry --port $REGISTRY_PORT --snapshot ${snapshot} &
             napalm_REGISTRY_PID=$!
+            trap "kill $napalm_REGISTRY_PID" EXIT
 
             while ! nc -z localhost $REGISTRY_PORT; do
               echo waiting for registry to be alive on port $REGISTRY_PORT
@@ -217,9 +218,6 @@ let
                 if [ -d node_modules ]; then find node_modules -type d -name bin | \
                   while read file; do patchShebangs $file; done; fi
               done
-
-            echo "Shutting down napalm registry"
-            kill $napalm_REGISTRY_PID
 
             runHook postBuild
           '';

--- a/default.nix
+++ b/default.nix
@@ -149,9 +149,7 @@ let
           haskellPackages.napalm-registry
           pkgs.fswatch
           pkgs.jq
-          pkgs.netcat-gnu
           pkgs.nodejs
-          pkgs.lsof
           waitForAndGetPort
         ];
 

--- a/default.nix
+++ b/default.nix
@@ -188,7 +188,7 @@ let
             sourceRoot=$PWD
 
             echo "Starting napalm registry"
-            napalm-registry --port 4444 --snapshot ${snapshot} &
+            napalm-registry --snapshot ${snapshot} &
             napalm_REGISTRY_PID=$!
             trap "waitForAndGetPort $napalm_REGISTRY_PID; kill $napalm_REGISTRY_PID" EXIT
             echo "REGISTRY STARTED $napalm_REGISTRY_PID"

--- a/napalm-registry/Main.hs
+++ b/napalm-registry/Main.hs
@@ -79,7 +79,6 @@ parseConfig = Config <$>
     ) <*>
     (optional $ Opts.option Opts.auto (
       Opts.long "port" <>
-      -- Opts.value Nothing <>
       Opts.help "The to serve on, also used in the Tarball URL"
     )) <*>
     Opts.strOption (


### PR DESCRIPTION
This PR introduces a script to select an unused port for the registry. This should essentially address #10.  

The solution has a dependency on `lsof`, but since `nc` is used already, I think that should be okay.
Moreover, the registry is terminated via a `trap ... EXIT`, so it is shutdown even in case of unexpected errors.