### PR TITLE
Use Unix Domain Socket for the registry

### DIFF
--- a/napalm-registry/package.yaml
+++ b/napalm-registry/package.yaml
@@ -16,6 +16,7 @@ dependencies:
     - time
     - unordered-containers
     - uri-encode
+    - network
     - warp
     - zlib
 


### PR DESCRIPTION
First of all: Thank you for `napalm`! I've been using `naersk` since quite a while and I really like **not** having lots of redundant generated files laying around in the repository :-)

This is an alternative solution to pull request #21, which implements picking a random TCP port for the registry. While I haven't found the exact reason why it has to be randomized, I can only guess that it's to prevent port conflicts in unsandboxed builds.

The implementation also has few ugly workarounds (eg. using `lsof` to get the port number), but the main issue I see is that even if the port is random, any user/process on the system can still connect to that port.

So instead of picking a random TCP port, let's simply not use IP sockets *at all* and use ip2unix to force NPM into connecting to the Unix socket.

We're now using a dummy IP address (`127.0.0.100`) for the registry URL in order to be able to match the registry URL in the ip2unix rule as a distinct host and at the same time prevent silent failure in case we forgot to transform/wrap sockets at some point.

Fixes: #4
Fixes: #10