### PR TITLE
Run hooks in configurePhase

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -165,7 +165,13 @@ let
           npmCommands = pkgs.lib.concatStringsSep "\n" npmCommands;
           buildInputs = newBuildInputs;
 
-          configurePhase = attrs.configurePhase or "export HOME=$(mktemp -d)";
+          configurePhase = attrs.configurePhase or ''
+            runHook preConfigure
+
+            export HOME=$(mktemp -d)
+
+            runHook postConfigure
+          '';
 
           buildPhase = attrs.buildPhase or ''
             runHook preBuild


### PR DESCRIPTION
`﻿stdenv`’s `configurePhase` runs `pre` and `postConfigure` hooks, we should do the same when overriding `configurePhase` to make overriding easier.

Cherry-picked from https://github.com/nmattia/napalm/pull/11.
