### PR TITLE
Fix packageLock example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Alternatively provide the path to the package-lock file:
 
 ``` nix
 let
-    napalm = pkgs.callPackage <napalm> { packageLock = <path/to/package-lock>; };
-in napalm.buildPackage ./. {}
+    napalm = pkgs.callPackage <napalm> {};
+in napalm.buildPackage ./. { packageLock = <path/to/package-lock>; }
 ```
 
 ## Napalm - a lightweight npm registry


### PR DESCRIPTION
It looks like the parameter was passed in the wrong place.